### PR TITLE
Show more of the file path of downloaded files

### DIFF
--- a/src/OneDriveGUI.py
+++ b/src/OneDriveGUI.py
@@ -2619,6 +2619,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         logging.info(data)
         file_path = f"{_sync_dir}" + "/" + data["file_path"]
         absolute_path = QFileInfo(file_path).absolutePath().replace(" ", "%20")
+        relative_path_display = os.path.relpath(QFileInfo(file_path).absolutePath(), _sync_dir + os.path.sep)
         parent_dir = re.search(r".+/([^/]+)/.+$", file_path).group(1)
         file_size = QFileInfo(file_path + ".partial").size() if QFileInfo(file_path).size() == 0 else QFileInfo(file_path).size()
         file_size_human = humanize_file_size(file_size)
@@ -2631,6 +2632,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         transfer_complete = data["transfer_complete"]
 
         logging.info("absolute path " + absolute_path)
+        logging.info("relative path " + relative_path_display)
 
         logging.info("parent dir " + parent_dir)
         logging.info("progress: " + progress)
@@ -2662,7 +2664,8 @@ class MainWindow(QMainWindow, Ui_MainWindow):
             myQCustomQWidget.set_label_2(f"")
 
         elif transfer_complete:
-            myQCustomQWidget.set_label_1(f"Available in <a href=file:///{absolute_path}>{parent_dir}</a>")
+            shortened_path = shorten_path(relative_path_display, 32)
+            myQCustomQWidget.set_label_1(f"Available in <a href=file:///{absolute_path}>{shortened_path}</a>")
             myQCustomQWidget.set_label_2(f"{file_size_human}")
 
         elif file_operation == "Downloading":
@@ -3085,6 +3088,71 @@ def config_client_bin_path() -> str:
         return "onedrive"
     else:
         return gui_settings["SETTINGS"]["client_bin_path"]
+
+# Shorten a folder path to a given length by removing the middle of the path
+def shorten_path(path, limit):
+	# Split the path into individual segments
+	segments = path.split(os.path.sep)
+	num_segments = len(segments)
+	
+	# If the path is already shorter than the limit, return it as is
+	if len(path) <= limit:
+		return path
+	
+	# If there's only one segment, return it as is
+	if num_segments == 1:
+		return path
+	
+	# Keep track of the left and right halves of the path
+	left = segments[:-1]
+	right = [segments[-1]]
+	
+	# Join the left and right halves back together with "..." in the middle
+	def join(left, right):
+		# # If the right half is empty, return the left half plus "..."
+		if len(right) == 0:
+			return os.path.join(*left) + os.path.sep + '...'
+		
+		# If the left half is empty, return "..." plus the right half
+		if len(left) == 0:
+			return '...' + os.path.sep + os.path.join(*right)
+		
+		# Join the left and right halves back together with "..." in the middle
+		return os.path.join(*left) + os.path.sep + '...' + os.path.sep + os.path.join(*right)
+	
+	# Loop until we reach the limit or can no longer split the path
+	while len(path) > limit and len(segments) > 1:
+		# Find the middle of the path segments list
+		middle = num_segments // 2
+		
+		# Drop the path segment closest to the middle
+		if num_segments % 2 == 0:
+			# If there is only 1 element in each half, drop from the left half and exit the loop
+			if len(right) == 1 and len(left) == 1:
+				left.pop(middle-1)
+				path = join(left, right)
+				break
+			else:
+				# If the list has an even number of segments, choose the longer one
+				if len(left[middle-1]) >= len(right[0]):
+					left.pop(middle-1)
+				else:
+					right.pop(0)
+		else:
+			# If the list has an odd number of segments, just drop the middle one
+			left.pop(middle)
+		
+		# Update the segments, left, and right lists
+		segments = left + right
+		num_segments = len(segments)
+		
+		left = segments[:middle]
+		right = segments[middle:]
+		
+		# Update the total length of the path
+		path = join(left, right)
+	
+	return path
 
 
 if __name__ == "__main__":

--- a/src/ui/list_item_widget.ui
+++ b/src/ui/list_item_widget.ui
@@ -24,13 +24,13 @@
     <number>5</number>
    </property>
    <property name="topMargin">
-    <number>2</number>
+    <number>4</number>
    </property>
    <property name="rightMargin">
     <number>2</number>
    </property>
    <property name="bottomMargin">
-    <number>6</number>
+    <number>4</number>
    </property>
    <property name="horizontalSpacing">
     <number>5</number>
@@ -78,6 +78,7 @@
      <property name="font">
       <font>
        <pointsize>10</pointsize>
+       <weight>75</weight>
        <bold>true</bold>
       </font>
      </property>
@@ -88,6 +89,12 @@
    </item>
    <item row="2" column="2" rowspan="2">
     <widget class="QLabel" name="ls_label_2">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="maximumSize">
       <size>
        <width>170</width>
@@ -104,9 +111,15 @@
    </item>
    <item row="2" column="1" rowspan="2">
     <widget class="QLabel" name="ls_label_1">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="maximumSize">
       <size>
-       <width>250</width>
+       <width>290</width>
        <height>16777215</height>
       </size>
      </property>

--- a/src/ui/ui_list_item_widget.py
+++ b/src/ui/ui_list_item_widget.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'list_item_widget.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.2.3
+## Created by: Qt User Interface Compiler version 6.2.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
@@ -28,7 +28,7 @@ class Ui_list_item_widget(object):
         self.gridLayout.setObjectName(u"gridLayout")
         self.gridLayout.setHorizontalSpacing(5)
         self.gridLayout.setVerticalSpacing(2)
-        self.gridLayout.setContentsMargins(5, 2, 2, 6)
+        self.gridLayout.setContentsMargins(5, 4, 2, 4)
         self.toolButton = QToolButton(list_item_widget)
         self.toolButton.setObjectName(u"toolButton")
         self.toolButton.setEnabled(True)
@@ -53,6 +53,11 @@ class Ui_list_item_widget(object):
 
         self.ls_label_2 = QLabel(list_item_widget)
         self.ls_label_2.setObjectName(u"ls_label_2")
+        sizePolicy = QSizePolicy(QSizePolicy.Preferred, QSizePolicy.Preferred)
+        sizePolicy.setHorizontalStretch(0)
+        sizePolicy.setVerticalStretch(0)
+        sizePolicy.setHeightForWidth(self.ls_label_2.sizePolicy().hasHeightForWidth())
+        self.ls_label_2.setSizePolicy(sizePolicy)
         self.ls_label_2.setMaximumSize(QSize(170, 16777215))
         self.ls_label_2.setAlignment(Qt.AlignRight|Qt.AlignTrailing|Qt.AlignVCenter)
 
@@ -60,7 +65,12 @@ class Ui_list_item_widget(object):
 
         self.ls_label_1 = QLabel(list_item_widget)
         self.ls_label_1.setObjectName(u"ls_label_1")
-        self.ls_label_1.setMaximumSize(QSize(250, 16777215))
+        sizePolicy1 = QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
+        sizePolicy1.setHorizontalStretch(0)
+        sizePolicy1.setVerticalStretch(0)
+        sizePolicy1.setHeightForWidth(self.ls_label_1.sizePolicy().hasHeightForWidth())
+        self.ls_label_1.setSizePolicy(sizePolicy1)
+        self.ls_label_1.setMaximumSize(QSize(290, 16777215))
 
         self.gridLayout.addWidget(self.ls_label_1, 2, 1, 2, 1)
 


### PR DESCRIPTION
Improved the "Available in" part of the list such that it displays more of the file path, instead of just the containing folder. To give it a bit of extra room, I increased the max width of the label_1, since after a file is downloaded, the label_2 is usually much shorter.