### PR TITLE
Rclone import

### DIFF
--- a/src/OneDriveGUI.py
+++ b/src/OneDriveGUI.py
@@ -985,6 +985,11 @@ class wizardPage_rsync(QWizardPage):
         # Save the new profile.
         with open(PROFILES_FILE, "w") as profilefile:
             _profiles.write(profilefile)
+
+        if refresh_token is not None:
+            refresh_token_file = re.search(r"(.+)/.+$", config_path).group(1) + "/refresh_token"
+            with open(refresh_token_file, "w") as f:
+                f.write(refresh_token)
         
         # if an rclone alias was provided, treat it as an "include" dir
         if include_dir is not None:


### PR DESCRIPTION
In support of #102, this implements:

- class `wizardPage_rsync` - an attempt at a functional QWizardPage. Never done this before, almost certainly needs attention. The rest of the GUI has not been modified to create a path to it (I don't know how).
- function `import_rclone` - handling of rclone-derived data, comments below.
- function `parse_rclone_remote` - tool for reading a remote configuration from an rclone config file. Fairly minimal since, unlike OD, the format is "correct" INI. 

If an rclone `onedrive` remote is provided, a new config is created (largely reusing code from the "create config" page). The drive_id is taken from rclone. The refresh_token is also taken, since it belongs to the same user, and written to the `refresh_token` file. Information on the this rclone feature is [here](https://rclone.org/onedrive/).

If an rclone `alias` remote is provided, it is split into the "real remote" (which should be a `onedrive`, and is used to populate the import function) and the path that was aliased. The path is then listed in the `sync_list` file, which will include only that path in sync. Information on this rclone feature is [here](https://rclone.org/alias/). I feel there should be more error handling here, but I'm not sure what failure cases would look like.

Decision for maintainers: whether to use the rclone "remote_name" as the new profile's name, or whether to use the user-provided value. 

Here is a sample rclone.conf (with realistic, but bogus, values). [rclone.conf.txt](https://github.com/bpozdena/OneDriveGUI/files/11317537/rclone.conf.txt)
