### PR TITLE
README: Fix install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ A simple GUI for [Linux OneDrive Client](https://github.com/abraunegg/onedrive),
 	```
 1) Install dependencies:
 	```sh
-	python3 -m pip3 install -r requirements.txt
+	python3 -m pip install -r requirements.txt
 	```
 
 1) Start OneDrive GUI:


### PR DESCRIPTION
When running via `python3`, the `pip` package name should be used instead of the `pip3` script name, see [1].

[1]: https://stackoverflow.com/a/72962566/1127485