### PR TITLE
Update version requirements to be compatible with python 3.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-PySide6==6.2.2.1
-requests==2.27.1
+PySide6==6.6.1
+requests==2.31.0


### PR DESCRIPTION
The current version fails to start on Arch with python 3.11

Note: This will make it incompatible with python < 3.8