### PR TITLE
fix: window icon under Wayland

### DIFF
--- a/src/OneDriveGUI.py
+++ b/src/OneDriveGUI.py
@@ -18,6 +18,7 @@ from global_config import DIR_PATH
 
 app = QApplication(sys.argv)
 app.setApplicationName("OneDriveGUI")
+app.setDesktopFileName("OneDriveGUI")
 app.setWindowIcon(QIcon(DIR_PATH + "/resources/images/icons8-clouds-80-dark-edge.png"))
 
 


### PR DESCRIPTION
This pull request sets the correct desktop filename to rectify the window icon under Wayland session.