### PR TITLE
fix: .desktop file

### DIFF
--- a/src/resources/OneDriveGUI.desktop
+++ b/src/resources/OneDriveGUI.desktop
@@ -1,8 +1,9 @@
 [Desktop Entry]
 Name=OneDriveGUI
-StartupNotify=true
-Exec=/usr/bin/python3 /home/bob/host_share/Python/OneDriveGUI/src/OneDriveGUI.py
+Comment=A simple GUI for OneDrive Linux client
+Exec=OneDriveGUI
 Terminal=false
-Path=/home/bob/host_share/Python/OneDriveGUI/src/resources/images
-Icon=/home/bob/host_share/Python/OneDriveGUI/src/resources/images/icons8-clouds-48.png
 Type=Application
+Icon=OneDriveGUI
+Categories=Network;Office
+StartupNotify=true


### PR DESCRIPTION
- An example .desktop file of PyQt application ([Anki](https://github.com/ankitects/anki/blob/main/qt/bundle/lin/anki.desktop)):
```desktop
[Desktop Entry]
Name=Anki
Comment=An intelligent spaced-repetition memory training program
GenericName=Flashcards
Exec=anki %f
TryExec=anki
Icon=anki
Categories=Education;Languages;KDE;Qt;
Terminal=false
Type=Application
Version=1.0
MimeType=application/x-apkg;application/x-anki;application/x-ankiaddon;
#should be removed eventually as it was upstreamed as to be an XDG specification called SingleMainWindow
X-GNOME-SingleWindow=true
SingleMainWindow=true
StartupWMClass=anki
```