### PR TITLE
Fix setup wizard display

### DIFF
--- a/src/main_window.py
+++ b/src/main_window.py
@@ -257,8 +257,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
             logging.info("[GUI] Minimizing main window to taskbar/dock")
 
     def show_setup_wizard(self):
-        # self.setup_wizard = SetupWizard()
-        self.setup_wizard.show()
+        setup_wizard.show()
 
     def show_settings_window(self):
         profile_settings_window.show()


### PR DESCRIPTION
The setup_wizard is initialized globally in its file, so just use it from the import. This fixes a problem where new users could not launch the application without creating a configuration file.