### PR TITLE
Update main_window.py

### DIFF
--- a/src/main_window.py
+++ b/src/main_window.py
@@ -30,6 +30,9 @@ import subprocess
 
 
 from wizard import setup_wizard
+# other import, lets see if this helps
+from wizard import SetupWizard
+
 from profile_settings_window import profile_settings_window
 
 from options import (
@@ -257,7 +260,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
             logging.info("[GUI] Minimizing main window to taskbar/dock")
 
     def show_setup_wizard(self):
-        # self.setup_wizard = SetupWizard()
+        self.setup_wizard = SetupWizard() #this line was commented out, lets see if uncommenting fix it
         self.setup_wizard.show()
 
     def show_settings_window(self):


### PR DESCRIPTION
Pull Request: Fix missing SetupWizard import causing crash on startup

Describe the bug
Running the GUI as described in the README causes a NameError: name 'SetupWizard' is not defined at startup. This happens because the class SetupWizard is not imported from the wizard module, only setup_wizard is imported.

To Reproduce
Steps to reproduce the behavior:

    # Clone the repository:
    git clone https://github.com/bpozdena/OneDriveGUI.git

    # Change directory:
    cd OneDriveGUI

    # Install dependencies (preferably in a conda environment):
    conda create -n onedrive-py
    conda activate onedrive-py
    conda install requests PySide6_Essentials

    #Run the GUI (while fixing some GL issues)

    cd  src
    QT_XCB_GL_INTEGRATION=none QT_QUICK_BACKEND=software python3 OneDriveGUI.py

Observe the crash with the error:

<details><summary>console output</summary>
<p>

(onedrive-py) kranich@birds-with-hats:~/OneDriveGUI/src$ QT_XCB_GL_INTEGRATION=none QT_QUICK_BACKEND=software python OneDriveGUI.py
2025-06-16 00:14:06,352 [utils.py:102][fn=config_client_bin_path][INFO] - Onedrive client location: 'onedrive'
2025-06-16 00:14:06,357 [utils.py:96][fn=get_installed_client_version][DEBUG] - [GUI] Installed client version is 256
2025-06-16 00:14:06,357 [global_config.py:45][fn=create_global_config][DEBUG] - [GUI] - loading default config {'onedrive': {'sync_dir': '"~/OneDrive"', 'monitor_interval': '"300"', 'log_dir': '"/var/log/onedrive/"', 'drive_id': '""', 'upload_only': '"false"', 'check_nomount': '"false"', 'check_nosync': '"false"', 'download_only': '"false"', 'disable_notifications': '"false"', 'disable_upload_validation': '"false"', 'enable_logging': '"false"', 'force_http_11': '"false"', 'local_first': '"false"', 'no_remote_delete': '"false"', 'skip_symlinks': '"false"', 'debug_https': '"false"', 'skip_dotfiles': '"false"', 'dry_run': '"false"', 'min_notify_changes': '"5"', 'monitor_log_frequency': '"12"', 'monitor_fullscan_frequency': '"12"', 'sync_root_files': '"false"', 'classify_as_big_delete': '"1000"', 'user_agent': '""', 'remove_source_files': '"false"', 'skip_dir_strict_match': '"false"', 'application_id': '""', 'resync': '"false"', 'bypass_data_preservation': '"false"', 'azure_ad_endpoint': '""', 'azure_tenant_id': '"common"', 'sync_business_shared_items': '"false"', 'sync_dir_permissions': '"700"', 'sync_file_permissions': '"600"', 'rate_limit': '"125000000"', 'operation_timeout': '"3600"', 'webhook_enabled': '"false"', 'webhook_public_url': '""', 'webhook_listening_host': '""', 'webhook_listening_port': '"8888"', 'webhook_expiration_interval': '"86400"', 'webhook_renewal_interval': '"43200"', 'disable_download_validation': '"false"', 'connect_timeout': '"30"', 'data_timeout': '"240"', 'display_running_config': '"false"', 'ip_protocol_version': '"1"', 'threads': '"8"', 'use_recycle_bin': '"false"', 'recycle_bin_path': '""', 'force_session_upload': '"false"', 'delay_inotify_processing': '"false"', 'inotify_delay': '"5"', 'skip_file': '"~*|.~*|*.tmp|*.swp|*.partial"', 'skip_dir': '""'}}
2025-06-16 00:14:06,357 [global_config.py:75][fn=create_global_config][DEBUG] - [GUI]{}
QXcbIntegration: Cannot create platform OpenGL context, neither GLX nor EGL are enabled
Attribute Qt::AA_ShareOpenGLContexts must be set before QCoreApplication is created.
2025-06-16 00:14:06,446 [OneDriveGUI.py:51][fn=<module>][INFO] - Starting OneDriveGUI v1.2.0
Traceback (most recent call last):
  File "/home/kranich/OneDriveGUI/src/OneDriveGUI.py", line 56, in <module>
    main_window = MainWindow()
                  ^^^^^^^^^^^^
  File "/home/kranich/OneDriveGUI/src/main_window.py", line 83, in __init__
    self.show_setup_wizard()
  File "/home/kranich/OneDriveGUI/src/main_window.py", line 261, in show_setup_wizard
    self.setup_wizard.show()


</p>
</details>     
NameError: name 'SetupWizard' is not defined

Expected behavior
The GUI should start normally and open the setup wizard window without errors.


Log
Relevant excerpt from the terminal output:

NameError: name 'SetupWizard' is not defined. Did you mean: 'setup_wizard'?

System Info

    Linux distribution: Linux Mint 22.1 x86_64

    Desktop environment: Cinnamon 6.4.8

    Window manager: Mutter (Muffin)

    Kernel: 6.15.2-061502-generic

    Shell: bash 5.2.21

    Python version: 3.10.x (inside conda environment)

    OneDrive client version: 256 (as detected by the GUI)

OneDriveGUI info

    Installation method: Cloned from GitHub and run inside a conda environment (not system-wide Python, because system Python packages are managed via apt)

    AppImage: Not applicable

Fix:
Add missing import for SetupWizard in src/main_window.py:

from wizard import setup_wizard
from wizard import SetupWizard  # <-- added this line to fix NameError
