### PR TITLE
Use config to setup login URL

### DIFF
--- a/src/main_window.py
+++ b/src/main_window.py
@@ -1071,14 +1071,10 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         self.config_file = global_config[profile]["config_file"].strip('"')
         self.config_dir = re.search(r"(.+)/.+$", self.config_file).group(1)
 
-        # use static URL for now. TODO: use auth files in the future
-        url = (
-            "https://login.microsoftonline.com/common/oauth2/v2.0/authorize?client_id=d50ca740-c83f-4d1b-b616"
-            "-12c519384f0c&scope=Files.ReadWrite%20Files.ReadWrite.all%20Sites.Read.All%20Sites.ReadWrite.All"
-            "%20offline_access&response_type=code&prompt=login&redirect_uri=https://login.microsoftonline.com"
-            "/common/oauth2/nativeclient"
-        )
-        self.lw.loginFrame.setUrl(QUrl(url))
+        application_id = global_config[profile].get("onedrive", {}).get("application_id", "d50ca740-c83f-4d1b-b616-12c519384f0c").strip('"')
+        azure_tenant_id = global_config[profile].get("onedrive", {}).get("azure_tenant_id", "common").strip('"')
+        loginUrl = f"https://login.microsoftonline.com/{azure_tenant_id}/oauth2/v2.0/authorize?client_id={application_id}&scope=Files.ReadWrite%20Files.ReadWrite.all%20Sites.Read.All%20Sites.ReadWrite.All%20offline_access&response_type=code&prompt=login&redirect_uri=https://login.microsoftonline.com/{azure_tenant_id}/oauth2/nativeclient"
+        self.lw.loginFrame.setUrl(QUrl(loginUrl))
 
         # Wait for user to login and obtain response URL
         self.lw.loginFrame.urlChanged.connect(lambda: self.get_response_url(self.lw.loginFrame.url().toString(), profile))
@@ -1088,7 +1084,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         self.window2 = QWidget()
         self.window2.setWindowIcon(QIcon(DIR_PATH + "/resources/images/icons8-cloud-80.png"))
         self.lw2 = Ui_ExternalLoginWindow()
-        self.lw2.setupUi(self.window2)
+        self.lw2.setupUi(self.window2, global_config[profile].get("onedrive", {}))
         self.window2.show()
         self.window2.setWindowTitle(f"OneDrive login for profile {profile}")
 

--- a/src/main_window.py
+++ b/src/main_window.py
@@ -1073,7 +1073,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
 
         application_id = global_config[profile].get("onedrive", {}).get("application_id", "d50ca740-c83f-4d1b-b616-12c519384f0c").strip('"')
         azure_tenant_id = global_config[profile].get("onedrive", {}).get("azure_tenant_id", "common").strip('"')
-        loginUrl = f"https://login.microsoftonline.com/{azure_tenant_id}/oauth2/v2.0/authorize?client_id={application_id}&scope=Files.ReadWrite%20Files.ReadWrite.all%20Sites.Read.All%20Sites.ReadWrite.All%20offline_access&response_type=code&prompt=login&redirect_uri=https://login.microsoftonline.com/{azure_tenant_id}/oauth2/nativeclient"
+        loginUrl = f"https://login.microsoftonline.com/{azure_tenant_id}/oauth2/v2.0/authorize?client_id={application_id}&scope=Files.ReadWrite%20Files.ReadWrite.All%20Sites.ReadWrite.All%20offline_access&response_type=code&prompt=login&redirect_uri=https://login.microsoftonline.com/{azure_tenant_id}/oauth2/nativeclient"
         self.lw.loginFrame.setUrl(QUrl(loginUrl))
 
         # Wait for user to login and obtain response URL

--- a/src/ui/ui_external_login.py
+++ b/src/ui/ui_external_login.py
@@ -31,10 +31,13 @@ from PySide6.QtWidgets import QApplication, QLabel, QLineEdit, QPushButton, QSiz
 
 
 class Ui_ExternalLoginWindow(object):
-    def setupUi(self, ExternalLoginWindow):
+    def setupUi(self, ExternalLoginWindow, onedriveConfig):
         if not ExternalLoginWindow.objectName():
             ExternalLoginWindow.setObjectName("ExternalLoginWindow")
         ExternalLoginWindow.resize(783, 321)
+
+        self.onedriveConfig = onedriveConfig
+
         self.verticalLayout = QVBoxLayout(ExternalLoginWindow)
         self.verticalLayout.setObjectName("verticalLayout")
         self.layout_external_login = QVBoxLayout()
@@ -81,10 +84,13 @@ class Ui_ExternalLoginWindow(object):
                 None,
             )
         )
+        application_id = self.onedriveConfig.get("application_id", "d50ca740-c83f-4d1b-b616-12c519384f0c").strip('"')
+        azure_tenant_id = self.onedriveConfig.get("azure_tenant_id", "common").strip('"')
+        loginUrl = f"https://login.microsoftonline.com/{azure_tenant_id}/oauth2/v2.0/authorize?client_id={application_id}&amp;scope=Files.ReadWrite%20Files.ReadWrite.all%20Sites.Read.All%20Sites.ReadWrite.All%20offline_access&amp;response_type=code&amp;prompt=login&amp;redirect_uri=https://login.microsoftonline.com/{azure_tenant_id}/oauth2/nativeclient"
         self.label_2.setText(
             QCoreApplication.translate(
                 "ExternalLoginWindow",
-                '<html><head/><body><p>1)Login to OneDrive in your browser by <a href="https://login.microsoftonline.com/common/oauth2/v2.0/authorize?client_id=d50ca740-c83f-4d1b-b616-12c519384f0c&amp;scope=Files.ReadWrite%20Files.ReadWrite.all%20Sites.Read.All%20Sites.ReadWrite.All%20offline_access&amp;response_type=code&amp;prompt=login&amp;redirect_uri=https://login.microsoftonline.com/common/oauth2/nativeclient"><span style=" text-decoration: underline; color:#5e81ac;">clicking this link.</span></a></p><p>2)Copy the response URI from your browser\'s address bar to the below field. </p><p>3)Press Save.</p></body></html>',
+                f'<html><head/><body><p>1)Login to OneDrive in your browser by <a href="{loginUrl}"><span style=" text-decoration: underline; color:#5e81ac;">clicking this link.</span></a></p><p>2)Copy the response URI from your browser\'s address bar to the below field. </p><p>3)Press Save.</p></body></html>',
                 None,
             )
         )

--- a/src/ui/ui_external_login.py
+++ b/src/ui/ui_external_login.py
@@ -86,7 +86,7 @@ class Ui_ExternalLoginWindow(object):
         )
         application_id = self.onedriveConfig.get("application_id", "d50ca740-c83f-4d1b-b616-12c519384f0c").strip('"')
         azure_tenant_id = self.onedriveConfig.get("azure_tenant_id", "common").strip('"')
-        loginUrl = f"https://login.microsoftonline.com/{azure_tenant_id}/oauth2/v2.0/authorize?client_id={application_id}&amp;scope=Files.ReadWrite%20Files.ReadWrite.all%20Sites.Read.All%20Sites.ReadWrite.All%20offline_access&amp;response_type=code&amp;prompt=login&amp;redirect_uri=https://login.microsoftonline.com/{azure_tenant_id}/oauth2/nativeclient"
+        loginUrl = f"https://login.microsoftonline.com/{azure_tenant_id}/oauth2/v2.0/authorize?client_id={application_id}&amp;scope=Files.ReadWrite%20Files.ReadWrite.All%20Sites.ReadWrite.All%20offline_access&amp;response_type=code&amp;prompt=login&amp;redirect_uri=https://login.microsoftonline.com/{azure_tenant_id}/oauth2/nativeclient"
         self.label_2.setText(
             QCoreApplication.translate(
                 "ExternalLoginWindow",


### PR DESCRIPTION
Actually we should use the URL provided by onedrive application (I let implement it to @bpozdena), but for now let's construct the URL by reading application_id and azure_tenant_id.

Closes https://github.com/bpozdena/OneDriveGUI/issues/285 .