### PR TITLE
Small cleanups: duplicate QTimer import + set_check_box_state hygiene

### DIFF
--- a/src/main_window.py
+++ b/src/main_window.py
@@ -1,4 +1,4 @@
-from PySide6.QtCore import QTimer, QUrl, QFileInfo, Qt, Signal, Slot, QTimer
+from PySide6.QtCore import QTimer, QUrl, QFileInfo, Qt, Signal, Slot
 from PySide6.QtGui import QIcon, QPixmap, QDesktopServices
 from PySide6.QtWidgets import (
     QWidget,

--- a/src/profile_settings_window.py
+++ b/src/profile_settings_window.py
@@ -682,12 +682,10 @@ class ProfileSettingsPage(QWidget, Ui_profile_settings):
         self.temp_profile_config["onedrive"][f"{property}"] = f'"{value}"'
 
     def set_check_box_state(self):
-        sender = self.sender()
         _property = self.sender().objectName()
-        print("test " + _property)
         try:
             property = re.search(r"checkBox_(.+)", _property).group(1)
-        except:
+        except AttributeError:
             property = re.search(r"groupBox_(.+)", _property).group(1)
 
         if self.sender().isChecked():


### PR DESCRIPTION
## Summary

Two small no-behavior-change cleanups surfaced by pyflakes on the post-restructure source tree:

- **`src/main_window.py`** — Remove the duplicate `QTimer` at the end of the `from PySide6.QtCore import …` line. Python silently dedupes, so no runtime impact, but the duplicate is a leftover from the monolithic-to-modular extraction.
- **`src/profile_settings_window.py` (`set_check_box_state`)** — Three small fixes to one function:
  - Remove the unused local `sender = self.sender()` (assigned but never used).
  - Remove the leftover `print("test " + _property)` debug line.
  - Narrow the bare `except:` to `except AttributeError:` — the exception that `re.search(...).group(1)` actually raises when there is no match. The bare form would also swallow `KeyboardInterrupt`, `SystemExit`, and unrelated bugs.

## Test plan

- [x] All files in `src/` compile cleanly under Python 3.12 (`python3 -m compileall -q src/`)
- [x] Pyflakes no longer reports the two findings the PR addresses (`pyflakes src/main_window.py src/profile_settings_window.py`)
- [x] Normal control flow unchanged — the bare-except → `AttributeError` change preserves the existing fall-through behavior for the documented checkBox/groupBox name patterns; only out-of-band exceptions (e.g. `KeyboardInterrupt`) are no longer suppressed.