### PR TITLE
Add .venv to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 venv/
 venv2/
+.venv/
 .qt_for_python/
 src/__thrash/
 src/nohup.out


### PR DESCRIPTION
## Summary

- Adds `.venv/` to `.gitignore` alongside the existing `venv/` and `venv2/` entries, so virtual environments created with the `.venv` naming convention are excluded from version control.

## Test plan

- [ ] Confirm `.venv/` directories are not tracked by git after this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)