### PR TITLE
Add .venv to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 venv/
 venv2/
-.venv/
 .qt_for_python/
 src/__thrash/
 src/nohup.out

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 venv/
 venv2/
+.venv/
 .qt_for_python/
 src/__thrash/
 src/nohup.out


### PR DESCRIPTION
## Summary

- Adds `.venv/` to `.gitignore` alongside the existing `venv/` and `venv2/` entries, covering the common convention of naming virtual environments `.venv`.

## Test plan

- [ ] Confirm `.venv/` directories are not tracked by git after this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)